### PR TITLE
only treat None as a value not used for matching

### DIFF
--- a/src/matchbox/matchbox.py
+++ b/src/matchbox/matchbox.py
@@ -149,7 +149,7 @@ class MatchBox(object):
         :rtype: CharacteristicValue
         """
         values = getattr(indexed_object, self._characteristic)
-        if values and isinstance(values, Hashable):
+        if values is not None and isinstance(values, Hashable):
             values = [values]
         return CharacteristicValue(
             values,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -61,9 +61,9 @@ def test_unknown_becoms_known():
     assert some_object not in box.index['known']
 
 
-@pytest.mark.parametrize('empty_value', (None, [], ()))
+@pytest.mark.parametrize('empty_value', (None, []))
 def test_matchbox_empty_characteristic(empty_value):
-    """Check simple adding object to index if it does match characteristic's value."""
+    """Check extracting object's values if it is recognised as not used."""
     ob = IndexedObject(empty_value)
 
     box = MatchBox('characteristic')
@@ -72,3 +72,17 @@ def test_matchbox_empty_characteristic(empty_value):
     assert not box.index, "index should be empty."
     assert not box.mismatch_unknown, "collection for not matching unknown should also be empty."
     assert not box, "box should be empty"
+
+
+@pytest.mark.parametrize('falsy_value', ((), False, ''))
+def test_matchbox_falsy_used_characteristic(falsy_value):
+    """Check simple adding object to index if it does match characteristic's value."""
+    ob = IndexedObject(falsy_value)
+
+    box = MatchBox('characteristic')
+    assert box.extract_characteristic_value(ob).values, "values is not falsy"
+    assert not box.extract_characteristic_value(ob).values[0], "though element is"
+    box.add(ob)
+    assert falsy_value in box.index, "index should not be empty, with key for the falsy_value instead."
+    assert ob in box.mismatch_unknown, "due to characteristic_match, this should be fileld."
+    assert box, "box should not be empty"

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -26,7 +26,8 @@ def test_match():
     box.index['other'].add(totally_other)
     box.mismatch_unknown.add(element1)
     box.index['test'].add(element2)
-    assert box.match({element1, element2, totally_other}, 'test') == {totally_other}, "only one element should match"
+    all_elements = {element1, element2, totally_other}
+    assert box.match(all_elements, 'test') == {totally_other}, "only one element should match"
 
 
 @pytest.mark.parametrize('characteristic_values', ('x', ['x', 'y'], ['z'], [1, 2, 3, None]))


### PR DESCRIPTION
This is due to the fact that some indexes might be as simple as True,False, and empty string or empty tuple, or even 0 might still be desired meaningful information
which leaves only None or empty list as an indicator of a values not viable to match on.