### PR TITLE
Pin all actions by their commi sha - closes #784

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,14 +15,16 @@ jobs:
     # Service containers to run with `container-job`
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - uses: fizyk/actions-reuse/.github/actions/uv@14e008c246b7b8eeab7cb5c543117471fee37310 # v5.1.2
       with:
         python-version: ${{ matrix.python-version }}
         command: "pytest benchmarks/  --benchmark-json output.json"
         allow-prereleases: true
     - name: Analyse benchmark results for Pull Requests
-      uses: benchmark-action/github-action-benchmark@v1.22.0
+      uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
       if: ${{ github.ref != 'refs/heads/main' }}
       with:
         name: Matchbox performance benchmarks on Python ${{ matrix.python-version }}
@@ -37,7 +39,7 @@ jobs:
         fail-on-alert: false
         alert-comment-cc-users: '@fizyk'
     - name: Store benchmark result for master branch
-      uses: benchmark-action/github-action-benchmark@v1.22.0
+      uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
       if: ${{ github.ref == 'refs/heads/main' }}
       with:
         name: Matchbox performance benchmarks on Python ${{ matrix.python-version }}

--- a/.github/workflows/sphinx-docs.yml
+++ b/.github/workflows/sphinx-docs.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: fizyk/actions-reuse/.github/actions/uv@14e008c246b7b8eeab7cb5c543117471fee37310 # v5.1.2
         with:
           python-version: "3.14"
           command: "sphinx-build -b html docs/source build/html"
           allow-prereleases: false
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4.1.0
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         with:
           publish_branch: gh-pages

--- a/newsfragments/784.misc.rst
+++ b/newsfragments/784.misc.rst
@@ -1,0 +1,2 @@
+Pin all actions by their commit hash.
+Set persist-credentials to false for benchmarks workflow.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and deployment workflow configurations to pin external action versions by commit hash for enhanced security and reproducibility of automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->