### PR TITLE
Trusted publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -4,9 +4,23 @@ on:
     tags:
       - v*
 jobs:
-  build-n-publish:
-    uses: fizyk/actions-reuse/.github/workflows/shared-pypi.yml@14e008c246b7b8eeab7cb5c543117471fee37310 # v5.1.2
-    with:
-      publish: true
-    secrets:
-      pypi_token: ${{ secrets.pypi_token }}
+  build:
+    uses: ./.github/workflows/build.yml
+
+  publish:
+    name: Publish Python 🐍 distributions 📦 to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions 📦
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: package
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          verbose: true

--- a/newsfragments/+0e693d39.misc.rst
+++ b/newsfragments/+0e693d39.misc.rst
@@ -1,0 +1,1 @@
+Add trusted publishing workflow


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored CI/CD publishing into separate build and publish jobs; build is reusable by other workflows.
  * Added a workflow trigger to allow invocation from other workflows.
  * Hardened publishing run with improved security settings and explicit artifact download before publishing.
  * Added a release note entry announcing the trusted publishing workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->