### PR TITLE
Modernise typing syntax

### DIFF
--- a/matchbox/box.py
+++ b/matchbox/box.py
@@ -17,9 +17,9 @@
 # along with matchbox.  If not, see <http://www.gnu.org/licenses/>.
 """Match box - for indexing objects by their fields."""
 
-from collections.abc import Hashable
+from collections.abc import Hashable, Iterable
 from dataclasses import dataclass
-from typing import Generic, Iterable, Set
+from typing import Generic
 
 from matchbox.index import ET, TT, MatchIndex
 
@@ -66,7 +66,7 @@ class MatchBox(MatchIndex[TT, ET]):
         super().__init__()
         self._characteristic = characteristic
 
-    def extract_traits(self, entity: ET) -> Trait:
+    def extract_traits(self, entity: ET) -> Trait[TT]:
         """Extract data required to classify entity.
 
         :param object entity:
@@ -97,7 +97,7 @@ class MatchBox(MatchIndex[TT, ET]):
 
         :param object entity:
         """
-        empty_traits: Set[TT] = set()
+        empty_traits: set[TT] = set()
         self.mismatch_unknown.discard(entity)
         for trait, entities in self.index.items():
             entities.discard(entity)

--- a/matchbox/index.py
+++ b/matchbox/index.py
@@ -18,7 +18,8 @@
 """Data structure that allows indexing includes and excludes of values."""
 
 from collections import defaultdict
-from typing import Dict, Generic, Hashable, Set, TypeVar
+from collections.abc import Hashable
+from typing import Generic, TypeVar
 
 ET = TypeVar("ET", bound=Hashable)
 TT = TypeVar("TT", bound=Hashable)
@@ -134,13 +135,13 @@ class MatchIndex(Generic[TT, ET]):
 
     def __init__(self) -> None:
         """Initialize the index."""
-        self.mismatch_unknown: Set[ET] = set()
+        self.mismatch_unknown: set[ET] = set()
         """
         This set will keep matching entities. They do not match unknown traits.
 
         Used for `self.index` default value, that means any previously unknown trait.
         """
-        self.index: Dict[TT, Set[ET]] = defaultdict(self.mismatch_unknown.copy)
+        self.index: dict[TT, set[ET]] = defaultdict(self.mismatch_unknown.copy)
 
     def add_mismatch(self, entity: ET, *traits: TT) -> None:
         """Add a mismatching entity to the index.
@@ -181,7 +182,7 @@ class MatchIndex(Generic[TT, ET]):
         # From now on, any new matching or mismatching index will mismatch this entity by default.
         self.mismatch_unknown.add(entity)
 
-    def mismatch(self, trait: TT) -> Set[ET]:
+    def mismatch(self, trait: TT) -> set[ET]:
         """Return a set of indexed entities that are mismatched by the trait.
 
         The returned set can be used for filtering by substracting it from another set created by a previous MatchIndex
@@ -193,7 +194,7 @@ class MatchIndex(Generic[TT, ET]):
         """
         return self.index[trait]
 
-    def match(self, collection: Set[ET], trait: TT) -> Set[ET]:
+    def match(self, collection: set[ET], trait: TT) -> set[ET]:
         """Filter out those entities from collection that do not match the trait.
 
         .. note ::

--- a/newsfragments/+d5d7239c.misc.rst
+++ b/newsfragments/+d5d7239c.misc.rst
@@ -1,0 +1,1 @@
+Modernise typing from pre-python 3.9 syntax


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized type annotations to use Python 3.9+ syntax with built-in generics instead of legacy `typing` module imports, improving code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->